### PR TITLE
Stop player motion when the mouse leaves the canvas

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -73,6 +73,14 @@ var target = {x: player.x, y: player.y};
 var c = document.getElementById('cvs');
 c.addEventListener('mousemove', gameInput, false);
 c.width = screenWidth; c.height = screenHeight;
+c.addEventListener('mouseout', outOfBounds, false);
+
+// register when the mouse goes off the canvas
+function outOfBounds() {
+  target = { x : screenWidth / 2, y : screenHeight / 2 };
+}
+
+
 
 var graph = c.getContext('2d');
 


### PR DESCRIPTION
This pull request fixes #44.  Mouseout event stops player motion until the canvas detects mouse movement again.