### PR TITLE
Enforce alphanumeric nicknames

### DIFF
--- a/client/css/main.css
+++ b/client/css/main.css
@@ -148,3 +148,9 @@ canvas {
 	margin: 10px; padding: 10px;
 	margin-top: 0;
 }
+
+#startMenu .input-error {
+  color : red;
+  display: none;
+  font-size : 12px;
+}

--- a/client/index.html
+++ b/client/index.html
@@ -19,6 +19,7 @@
         <div id="startMenu">
             <p>Open Agar</p>
             <input type="text" tabindex="0" autofocus placeholder="Enter your name here" id="playerNameInput" />
+            <b class="input-error">Nick must be alphanumeric characters only!</b>
             <br />
             <button id="startButton">Play</button>
             <br/>

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -13,14 +13,38 @@ function startGame() {
     animloop();
 }
 
-window.onload = function() {
-    document.getElementById('startButton').onclick = startGame;
+// check if nick is valid alphanumeric characters (and underscores)
+function validNick() {
+    var regex = /^\w+$/;
+    console.log("Regex Test", regex.exec(playerNameInput.value));
+    return regex.exec(playerNameInput.value) !== null;
+}
 
-    playerNameInput.addEventListener('keypress', function(e) {
+window.onload = function() {
+    'use strict';
+
+    var btn = document.getElementById('startButton'),
+        nickErrorText = document.querySelector('#startMenu .input-error');
+
+    btn.onclick = function () {
+
+        // check if the nick is valid
+        if (validNick()) {
+            startGame();
+        } else {
+            nickErrorText.style.display = 'inline';
+        }
+    };
+
+    playerNameInput.addEventListener('keypress', function (e) {
         var key = e.which || e.keyCode;
 
         if (key === KEY_ENTER) {
-            startGame();
+            if (validNick()) {
+                startGame();
+            } else {
+                nickErrorText.style.display = 'inline';
+            }
         }
     });
 };

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -15,7 +15,7 @@ function startGame() {
 
 // check if nick is valid alphanumeric characters (and underscores)
 function validNick() {
-    var regex = /^\w+$/;
+    var regex = /^\w*$/;
     console.log("Regex Test", regex.exec(playerNameInput.value));
     return regex.exec(playerNameInput.value) !== null;
 }


### PR DESCRIPTION
Fixes #140.  Enforces players to use alphanumeric nicknames.  Underscores and spaces are allowed, as well the empty nickname.  A screenshot is shown below.

![nick_error](https://cloud.githubusercontent.com/assets/896472/7950496/63626710-0969-11e5-96da-a4404067cde5.png)

