### PR TITLE
[bugfix] massToRadius used twice by drawFood

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -449,11 +449,10 @@
         return Math.sqrt(mass / Math.PI) * 10;
     }
 
-    function drawCircle(centerX, centerY, mass, sides) {
+    function drawCircle(centerX, centerY, radius, sides) {
         var theta = 0;
         var x = 0;
         var y = 0;
-        var radius = massToRadius(mass);
 
         graph.beginPath();
 


### PR DESCRIPTION
```massToRadius``` is used twice by ```drawFood``` (lines [L156](https://github.com/huytd/agar.io-clone/blame/master/client/js/app.js#L456) and [L476](https://github.com/huytd/agar.io-clone/blame/master/client/js/app.js#L476))