### PR TITLE
Fixed food and players rendering

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -106,8 +106,7 @@
     var foodConfig = {
         border: 0,
         borderColor: '#f39c12',
-        fillColor: '#f1c40f',
-        mass: 0.5
+        fillColor: '#f1c40f'
     };
 
     var playerConfig = {
@@ -472,7 +471,7 @@
         graph.strokeStyle = food.color.border || foodConfig.borderColor;
         graph.fillStyle = food.color.fill || foodConfig.fillColor;
         graph.lineWidth = foodConfig.border;
-        drawCircle(food.x - player.x + screenWidth / 2, food.y - player.y + screenHeight / 2, massToRadius(foodConfig.mass), 10);
+        drawCircle(food.x - player.x + screenWidth / 2, food.y - player.y + screenHeight / 2, food.radius, 10);
     }
 
     function drawPlayer() {

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -6,7 +6,7 @@ var cfg = require('../config.json');
 
 // determine mass from radius of circle
 exports.massToRadius = function (mass) {
-    return Math.sqrt(mass / Math.PI) * 10;
+    return 10 + Math.sqrt(mass);
 };
 
 

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -11,7 +11,7 @@ exports.validNick = function(nickname) {
 
 // determine mass from radius of circle
 exports.massToRadius = function (mass) {
-    return 10 + Math.sqrt(mass);
+    return 4 + Math.sqrt(mass) * 6;
 };
 
 


### PR DESCRIPTION
This **PR** replaces https://github.com/huytd/agar.io-clone/pull/235 and https://github.com/huytd/agar.io-clone/pull/239 beacause they come together.

Now renders food and players using ```radius``` given from server.