### PR TITLE
Added uglify for src compression

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var babel = require('gulp-babel');
 var jshint = require('gulp-jshint');
 var nodemon = require('gulp-nodemon');
+var uglify = require('gulp-uglify');
 
 gulp.task('build', ['build-client', 'build-server']);
 
@@ -12,8 +13,9 @@ gulp.task('lint-client', function () {
 });
 
 gulp.task('build-client', ['lint-client', 'move-client'], function () {
-  return gulp.src('client/js/*.js')
+  return gulp.src(['client/js/*.js'])
     .pipe(babel())
+    //.pipe(uglify())
     .pipe(gulp.dest('bin/client/js/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-babel": "^5.1.0",
     "gulp-jshint": "^1.11.0",
     "gulp-nodemon": "^2.0.3",
+    "gulp-uglify": "^1.2.0",
     "jshint": "^2.7.0",
     "nodemon": "^1.2.1"
   }


### PR DESCRIPTION
This PR adds `gulp-uglify` for JS source compression.  This results in a 50% smaller file for app.js.  Here are the results on my machine:

**Original**
![original](https://cloud.githubusercontent.com/assets/896472/8397407/345d4406-1d98-11e5-8cd0-050a4376e7e6.png)


**Minified**
![uglified](https://cloud.githubusercontent.com/assets/896472/8397408/3b2cb9c4-1d98-11e5-8f0a-fef75bb109fb.png)

