### PR TITLE
FIX: mass toggle actually changes player name text

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -246,10 +246,10 @@
         }
 
         if (on || (!off && !toggleMassState)) {
-            toggleMassState = true;
+            toggleMassState = 1;
             addSystemLine('Mass mode activated!');
         } else {
-            toggleMassState = false;
+            toggleMassState = 0;
             addSystemLine('Mass mode deactivated!');
         }
     }


### PR DESCRIPTION
Fixes a bug with the player mass chat toggle.  Typing `-mass` in the chat now has the expected behavior of toggling the mass view on and off.