### PR TITLE
Fix paths in move-client rule to include src/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('build-client', ['lint', 'move-client'], function () {
 });
 
 gulp.task('move-client', function () {
-  return gulp.src(['client/**/*.*', '!client/js/*.js'])
+  return gulp.src(['src/client/**/*.*', '!src/client/js/*.js'])
     .pipe(gulp.dest('./bin/client/'));
 });
 


### PR DESCRIPTION
In the "Move all source files to src directory." change the move-client
task wasn't updated to include src/ in the paths.