### PR TITLE
Change starting input focus to game canvas

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -409,9 +409,7 @@ function setupSocket(socket) {
         if (mobile) {
             document.getElementById('gameAreaWrapper').removeChild(document.getElementById('chatbox'));
         }
-        else {
-            document.getElementById('chatInput').select();
-        }
+		document.getElementById('cvs').focus();
     });
 
     socket.on('gameSetup', function(data) {


### PR DESCRIPTION
Fixes #301 

It is still possible to use **TAB** key to access chat quickly.

Tested on desktop, using the latest Google Chrome, Mozilla Firefox and Microsoft Edge (as of 28/09/2015).