### PR TITLE
Fix typo in command recognition error message

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -258,7 +258,7 @@ ChatClient.prototype.sendChat = function (key) {
                 if (commands[args[0]]) {
                     commands[args[0]].callback(args.slice(1));
                 } else {
-                    this.addSystemLine('Unrecoginised Command: ' + text + ', type -help for more info');
+                    this.addSystemLine('Unrecognized Command: ' + text + ', type -help for more info');
                 }
 
             // just a regular message - send along to server


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/360?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/360'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>