### PR TITLE
[issue371] Updated render order of viruses

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,8 +5,8 @@
     "limitSplit": 16,
     "defaultPlayerMass": 10,
 	"virus": {
-		"fill": "#9b59b6",
-		"stroke": "#9b50ba",
+    "fill": "#33ff33",
+  	"stroke": "#19D119",
 		"strokeWidth": 20,
 		"defaultMass": {
             "from": 100,

--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -898,7 +898,8 @@ function gameLoop() {
             drawgrid();
             foods.forEach(drawFood);
             fireFood.forEach(drawFireFood);
-
+            viruses.forEach(drawVirus);
+            
             if (borderDraw) {
                 drawborder();
             }
@@ -918,8 +919,6 @@ function gameLoop() {
 
             drawPlayers(orderMass);
             socket.emit('0', target); // playerSendTarget "Heartbeat".
-
-            viruses.forEach(drawVirus);
 
         } else {
             graph.fillStyle = '#333333';


### PR DESCRIPTION
- fixed issue #371
- User for now always renders on top of viruses. Later we can implement a way to change order based off of size.
- Updated the virus color back to green with a more definite border.
    - ```"fill": "#33ff33",
  	"stroke": "#19D119"```
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/372?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/372'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>