### PR TITLE
Updated jQuery and removed useless reference

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -57,8 +57,7 @@
         </div>
     </div>
     <!-- JS -->
-    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+    <script src="http://code.jquery.com/jquery-2.2.0.min.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Updated jQuery from 2.1.4 to 2.2.0, which has a variety of bug fixes and improvements. Removed jQuery UI which is not necessary for this project.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/huytd/agar.io-clone/pull/382%23issuecomment-177258131%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/huytd/agar.io-clone/pull/382%23issuecomment-177258131%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-01-30T17%3A35%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5935946%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/IgorAntun%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/huytd/agar.io-clone/pull/382#issuecomment-177258131'>General Comment</a></b>
- <a href='https://github.com/IgorAntun'><img border=0 src='https://avatars.githubusercontent.com/u/5935946?v=3' height=16 width=16'></a> Thanks :)


<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/382?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/382?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/382'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>