### PR TITLE
Fallback babel to ^.8.38 first, cc #428 #429

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wb9688 <wbertrums@gmail.com> (https://github.com/wb9688)"
   ],
   "dependencies": {
-    "babel": "^6.5.2",
+    "babel": "^5.8.38",
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
     "chai": "^3.0.0",


### PR DESCRIPTION
In #428, babel upgraded from v5 to v6 make a problem caused the app not work, so fallback to ^5.8.38 first, tested working. Let's make it work first, then see how to upgrade without breaking, maybe should also add more tests to increase the code coverage in test.