### PR TITLE
Bugfix for Keyboard Controls

### DIFF
--- a/src/client/js/canvas.js
+++ b/src/client/js/canvas.js
@@ -136,11 +136,11 @@ class Canvas {
     // Chat command callback functions.
     keyInput(event) {
     	var key = event.which || event.keyCode;
-    	if (key === global.KEY_FIREFOOD && this.reenviar) {
+    	if (key === global.KEY_FIREFOOD && this.parent.reenviar) {
             this.parent.socket.emit('1');
             this.parent.reenviar = false;
         }
-        else if (key === global.KEY_SPLIT && this.reenviar) {
+        else if (key === global.KEY_SPLIT && this.parent.reenviar) {
             document.getElementById('split_cell').play();
             this.parent.socket.emit('2');
             this.parent.reenviar = false;


### PR DESCRIPTION
Variable got the wrong name, so the if condition never got to true and you couldn't split/feed
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/439?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/439'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>