### PR TITLE
Fix spectate mode only showing a part of the game

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -607,5 +607,11 @@ window.addEventListener('resize', resize);
 function resize() {
     player.screenWidth = c.width = global.screenWidth = global.playerType == 'player' ? window.innerWidth : global.gameWidth;
     player.screenHeight = c.height = global.screenHeight = global.playerType == 'player' ? window.innerHeight : global.gameHeight;
+
+    if (global.playerType == 'spectate') {
+        player.x = global.gameWidth / 2;
+        player.y = global.gameHeight / 2;
+    }
+
     socket.emit('windowResized', { screenWidth: global.screenWidth, screenHeight: global.screenHeight });
 }


### PR DESCRIPTION
Hi, I'm trying to make the spectator mode work properly.

The center of view (player coordinates) was not being set properly, but to a random position on the game area. Therefore the spectator could only see a part of the game. Fixed that by updating the player coordinates to the center of the screen on the 'resize' event callback.

This pull request resolves issue #444.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/446?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/446'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>