### PR TITLE
Set the host in the configuration file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "host": "0.0.0.0",
     "port": 3000,
     "foodMass": 1,
     "fireFood": 20,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -718,7 +718,7 @@ setInterval(gameloop, 1000);
 setInterval(sendUpdates, 1000 / c.networkUpdateFactor);
 
 // Don't touch, IP configurations.
-var ipaddress = process.env.OPENSHIFT_NODEJS_IP || process.env.IP || '0.0.0.0';
+var ipaddress = process.env.OPENSHIFT_NODEJS_IP || process.env.IP || c.host;
 var serverport = process.env.OPENSHIFT_NODEJS_PORT || process.env.PORT || c.port;
 http.listen( serverport, ipaddress, function() {
     console.log('[DEBUG] Listening on ' + ipaddress + ':' + serverport);


### PR DESCRIPTION
It's practical to be able to define the host in the configuration file, like the port.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/huytd/agar.io-clone/pull/484?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/huytd/agar.io-clone/pull/484'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>