### PR TITLE
Hide overflow in body

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -5,6 +5,7 @@
 
 html, body {
     background-color: #222;
+    overflow: hidden;
 }
 
 html, body, canvas {


### PR DESCRIPTION
Added `overflow:hidden` to fix the positioning issues caused by the leaderboard update.

Fixes: #515, #520 